### PR TITLE
Add Apache Flink to streaming computation systems

### DIFF
--- a/_includes/index.md
+++ b/_includes/index.md
@@ -45,6 +45,7 @@ In Kappa Architecture, data is fed from the log store into a streaming computati
 * [Apache Spark](http://spark.apache.org/)
 * [Amazon Kinesis](https://aws.amazon.com/kinesis/)
 * [Kafka Streams](http://kafka.apache.org/documentation.html#streams)
+* [Apache Flink](https://flink.apache.org/)
 
 ### Serving layer stores
 


### PR DESCRIPTION
See http://flink.apache.org/features.html

> One Runtime for Streaming and Batch Processing
> 
> Flink uses one common runtime for data streaming applications and batch processing applications.
> Batch processing applications run efficiently as special cases of stream processing applications.
